### PR TITLE
fix(site): correct archive link on index

### DIFF
--- a/scripts/build-site.mjs
+++ b/scripts/build-site.mjs
@@ -38,7 +38,10 @@ if (dates.length === 0) {
 // --- index.html = latest report ---
 const latest = dates[0];
 const latestPath = path.join(ROOT, latest, `${latest}.html`);
-fs.copyFileSync(latestPath, path.join(ROOT, "index.html"));
+const latestHtml = fs
+  .readFileSync(latestPath, "utf8")
+  .replace(/href="\.\.\/archive\.html"/g, 'href="./archive.html"');
+fs.writeFileSync(path.join(ROOT, "index.html"), latestHtml, "utf8");
 console.log(`[build-site] index.html  ← ${latest}/${latest}.html`);
 
 // --- archive.html = list of all reports ---


### PR DESCRIPTION
首页中点击”历史归档“跳转逻辑错误
跳转url应该是https://leiting-eric.github.io/DailyBrief/archive.html，而不是https://leiting-eric.github.io/archive.html
即修改相应的路径，已验证有效