### PR TITLE
Add AI Weekly RSS source

### DIFF
--- a/sources.config.json
+++ b/sources.config.json
@@ -154,6 +154,20 @@
     ]
   },
   {
+    "id": "ai-weekly",
+    "name": "AI Weekly",
+    "type": "rss",
+    "url": "https://aiweekly.co/feed",
+    "category": "tech",
+    "subcategory": "ai-news",
+    "enabled": true,
+    "locales": [
+      "zh",
+      "en"
+    ],
+    "notes": "Tracks what influential AI experts and organizations are reading and sharing; three editions per week"
+  },
+  {
     "id": "smol-ai-news",
     "name": "Smol AI News",
     "type": "rss",


### PR DESCRIPTION
## Summary

- add AI Weekly as an enabled bilingual `ai-news` RSS source
- use its official public feed and document the expert-reading signal and three-times-weekly cadence
- keep `sources.config.json` as the only source of truth

AI Weekly helps readers discover what influential AI experts and organizations are reading and sharing right now, across models, agents, funding, policy, and research.

## Validation

- `sources.config.json` parses with 54 unique IDs and URLs
- repository source check passed: `✓ sources.config.json OK (54 sources)`
- repository dry run fetched 20 AI Weekly items and 551 items overall
- two unrelated existing sources reported their own network failures (`linuxdo` Cloudflare challenge and `smol-ai-news` HTTP 402); the dry run otherwise completed its report, then required interruption because the process retained an open handle
- `git diff --check`

## Disclosure

I am AI Weekly founder Alexis Dufresne, proposing my own publication. I used an AI assistant to help prepare and submit this pull request, and I reviewed the change and factual details before posting.
